### PR TITLE
Fixed minutes and seconds 10 value returning 01

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
           <option value=7>07</option>
           <option value=8>08</option>
           <option value=9>09</option>
-          <option value=1>10</option>
+          <option value=10>10</option>
           <option value=11>11</option>
           <option value=12>12</option>
           <option value=13>13</option>
@@ -114,7 +114,7 @@
           <option value=7>07</option>
           <option value=8>08</option>
           <option value=9>09</option>
-          <option value=1>10</option>
+          <option value=10>10</option>
           <option value=11>11</option>
           <option value=12>12</option>
           <option value=13>13</option>


### PR DESCRIPTION
Noticed while using this tool that the value for minutes and seconds would return as 01 whenever set to 10. 
Turns out that the value for 10 in the minutes and seconds selection drop downs was set as 1 instead of 10.

This pull request just fixes those two little typos, and now returns 10 when the select menus are set to 10.